### PR TITLE
Try to understand CloudFront's forwarded-proto as well

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -22,6 +22,13 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
   ''      $scheme;
 }
 
+# If we received a HTTP-CloudFront-Forwarded-Proto, pass it through; otherwise,
+# pass along the original value.
+map $http_cloudfront_forwarded_proto $proxy_x_forwarded_proto {
+  default $http_cloudfront_forwarded_proto;
+  ''      $proxy_x_forwarded_proto;
+}
+
 # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
 # Connection header that may have been passed to this server
 map $http_upgrade $proxy_connection {

--- a/test/default-host.bats
+++ b/test/default-host.bats
@@ -29,4 +29,12 @@ function setup {
 	# THEN querying the proxy with any other Host header → 200
 	run curl_container $SUT_CONTAINER / --head --header "Host: something.I.just.made.up"
 	assert_output -l 0 $'HTTP/1.1 200 OK\r'
+
+	# THEN querying the proxy with X-Forwarded-Proto → 200
+	run curl_container $SUT_CONTAINER / --head --header "X-Forwarded-Proto: https"
+	assert_output -l 0 $'HTTP/1.1 200 OK\r'
+
+	# THEN querying the proxy with HTTP-CloudFront-Forwarded-Proto → 200
+	run curl_container $SUT_CONTAINER / --head --header "HTTP-CloudFront-Forwarded-Proto: https"
+	assert_output -l 0 $'HTTP/1.1 200 OK\r'
 }


### PR DESCRIPTION
This PR attempts to make the nginx-proxy support custom CloudFront headers, which should fix the infinite HTTPS redirect loop.

@pebble/webops 
