### PR TITLE
Cloudfront support #2

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -17,7 +17,7 @@
 
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
 # scheme used to connect to this server
-map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+map $http_x_forwarded_proto $default_forwarded_proto {
   default $http_x_forwarded_proto;
   ''      $scheme;
 }
@@ -26,7 +26,7 @@ map $http_x_forwarded_proto $proxy_x_forwarded_proto {
 # pass along the original value.
 map $http_cloudfront_forwarded_proto $proxy_x_forwarded_proto {
   default $http_cloudfront_forwarded_proto;
-  ''      $proxy_x_forwarded_proto;
+  ''      $default_forwarded_proto;
 }
 
 # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any


### PR DESCRIPTION
There seems to be a bug with nginx where if you let the `map` return `$value` in `map $string $value` as one of the results, this result is empty and the nginx core just gets dumped.

Renaming to a different value to overcome this.

@pebble/webops 
