### PR TITLE
json logs

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -38,9 +38,19 @@ map $http_upgrade $proxy_connection {
 
 gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
 
-log_format vhost '$host $remote_addr - $remote_user [$time_local] '
-                 '"$request" $status $body_bytes_sent '
-                 '"$http_referer" "$http_user_agent"';
+log_format vhost '{"time": "$time_iso8601", '
+                   '"host": "$host", '
+                   '"remote_addr": "$remote_addr", '
+                   '"remote_user": "$remote_user", '
+                   '"body_bytes_sent": "$body_bytes_sent", '
+                   '"request_time": "$request_time", '
+                   '"status": "$status", '
+                   '"request": "$request", '
+                   '"request_uri": "$uri", '
+                   '"request_method": "$request_method", '
+                   '"http_referrer": "$http_referer", '
+                   '"http_x_forwarded_for": "$http_x_forwarded_for", '
+                   '"http_user_agent": "$http_user_agent"}';
 
 access_log off;
 


### PR DESCRIPTION
this works in terms of kibana handling json correctly which is the goal.
note however, `forego` prepends each log line with it's own string describing the process which breaks truly strict json logs. 

```
nginx.1    | {"time": "2016-06-21T19:13:37+00:00", "host": "some.example.com", "remote_addr": "192.168.99.1", "remote_user": "-", "body_bytes_sent": "7", "request_time": "0.001", "status": "200", "request": "GET /hi HTTP/1.1", "request_uri": "/hi", "request_method": "GET", "http_referrer": "-", "http_x_forwarded_for": "-", "http_user_agent": "curl/7.43.0"}
```
